### PR TITLE
AzureAD $RoleName switch handling improvements

### DIFF
--- a/PIMTools.psd1
+++ b/PIMTools.psd1
@@ -1,6 +1,6 @@
 @{
     # Version number of this module.
-    ModuleVersion     = '0.3.0.0'
+    ModuleVersion     = '0.4.0.0'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Desktop')

--- a/functions/New-AzureADPIMRequest.ps1
+++ b/functions/New-AzureADPIMRequest.ps1
@@ -2,7 +2,7 @@ function New-AzureADPIMRequest {
     [CmdletBinding()]
     param (
         [int]$DurationInHours = 8,
-        $RoleName = 'Global Reader',
+        $RoleName = '',
         $Reason = "Daily PIM elevation"
     )
 
@@ -58,7 +58,8 @@ function New-AzureADPIMRequest {
 
     switch ($RoleName) {
         'Global Administrator' { $roleDefinition = AzureADPreview\Get-AzureADMSPrivilegedRoleDefinition -ProviderId aadRoles -ResourceId $AzureADCurrentSessionInfo.TenantId -Filter "DisplayName eq 'Global Administrator'" }
-        Default { $roleDefinition = AzureADPreview\Get-AzureADMSPrivilegedRoleDefinition -ProviderId aadRoles -ResourceId $AzureADCurrentSessionInfo.TenantId | Out-GridView -PassThru }
+        '' { $roleDefinition = AzureADPreview\Get-AzureADMSPrivilegedRoleDefinition -ProviderId aadRoles -ResourceId $AzureADCurrentSessionInfo.TenantId | Out-GridView -PassThru }
+        Default { $roleDefinition = AzureADPreview\Get-AzureADMSPrivilegedRoleDefinition -ProviderId aadRoles -ResourceId $AzureADCurrentSessionInfo.TenantId | Where-Object {$_.DisplayName -eq $RoleName} }
     }
 
     $subject = AzureADPreview\Get-AzureADUser -Filter ("userPrincipalName eq" + "'" + $($AzureADCurrentSessionInfo.Account) + "'")


### PR DESCRIPTION
Change parameter default for $RoleName to null ('')
If $RoleName is null, prompt for Role using out-gridview
if $RoleName is defined, pass through without needing out-gridview by using where-object to filter