### PR TITLE
Remove "#requires -PSEdition Desktop"

### DIFF
--- a/PIMTools.psm1
+++ b/PIMTools.psm1
@@ -1,5 +1,3 @@
-#requires -PSEdition Desktop
-
 # Load functions from module subfolder
 $ModuleRoot = Split-Path -Path $MyInvocation.MyCommand.Path
 


### PR DESCRIPTION
Did a quick test and it seems to work fine for me. Tested with:

$PSVersionTable

Name                           Value
----                           -----
PSVersion                      7.2.2
PSEdition                      Core